### PR TITLE
Port and hostname in activty text support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ source venv/bin/activate
 pip install -r requirements.txt 
 ```
 
+### Test
+
+```
+pip install pytest
+pytest
+```
+
 ### Start App
 
 ```

--- a/main.py
+++ b/main.py
@@ -11,6 +11,9 @@ import re
 dash_app = Dash(__name__, title="CQL Trace Viewer")
 app = dash_app.server
 
+sending_regexp = 'Sending (.*) message to .*/(.*)[,:].* size[ =](.*) bytes'
+receiving_regexp = '(.*) message received from .*/([^:^ ]*)'
+
 trace_scatter = dcc.Graph(
     id='trace_scatter',
 )
@@ -31,7 +34,6 @@ dash_app.layout = html.Div([
     trace_scatter,
     trace_table
 ])
-
 
 def build_scatter_fig(df):
     source_root_timestamps = {}
@@ -63,7 +65,7 @@ def build_scatter_fig(df):
         trace_activities[source].append(trace_activity)
 
         # Collect messages being sent
-        sending_search = re.search('Sending (.*) message to /(.*), size=(.*) bytes', row['source_activity'], re.IGNORECASE)
+        sending_search = re.search(sending_regexp, row['source_activity'], re.IGNORECASE)
         if sending_search:
             message_source = row['source']
             message_type = sending_search.group(1)
@@ -77,7 +79,7 @@ def build_scatter_fig(df):
 
     for activity in flattened_activities:
         # Match received messages with sent messages
-        receiving_search = re.search('(.*) message received from /(.*) ', activity['activity'], re.IGNORECASE)
+        receiving_search = re.search( receiving_regexp, activity['activity'], re.IGNORECASE)
         if receiving_search:
             message_target = activity['source']
             message_type = receiving_search.group(1)

--- a/test_main.py
+++ b/test_main.py
@@ -1,0 +1,29 @@
+import re
+import pytest
+import main
+
+activity_sending_texts = [
+    ( "READS.RANGE_READ", "Sending READS.RANGE_READ message to /172.25.225.5, size=3783 bytes" ), # From trace.txt
+    ( "MUTATION_REQ", "Sending MUTATION_REQ message to /172.25.225.5:7000 message size 3783 bytes [Messaging-EventLoop-3-2]" ), # Cassandra 4.0.11/4.1.3/5.0-beta1 without hostname
+    ( "MUTATION_REQ", "Sending MUTATION_REQ message to cassandra-2/172.25.225.5:7000 message size=3783 bytes") # Cassandra 4.0.11/4.1.3/5.0-beta1 with hostname
+]
+
+@pytest.mark.parametrize("type, text" , activity_sending_texts)
+def test_sending_regexp(type, text):
+    search_result = re.search( main.sending_regexp, text)
+    assert search_result.group(1) == type
+    assert search_result.group(2) == "172.25.225.5"
+    assert search_result.group(3) == "3783"
+
+
+activity_receiving_texts = [
+    ( "READS.RANGE_READ", "READS.RANGE_READ message received from /172.25.146.4 [CoreThread-9]" ), # From trace.txt
+    ( "MUTATION_REQ","MUTATION_REQ message received from /172.25.146.4:7000 [Messaging-EventLoop-3-2] " ), # Cassandra 4.0.11/4.1.3/5.0-beta1 without hostname
+    ( "MUTATION_REQ","MUTATION_REQ message received from cassandra-2/172.25.146.4:7000 [Messaging-EventLoop-3-5]" ) # Cassandra 4.0.11/4.1.3/5.0-beta1 with hostname
+]
+@pytest.mark.parametrize("type, text" , activity_receiving_texts)
+def test_receiving_regexp(type, text):
+    search_result = re.search( main.receiving_regexp, text)
+    assert search_result.group(1) == type
+    assert search_result.group(2) == "172.25.146.4"
+


### PR DESCRIPTION
- Add support for port number in text, for example 192.168.1.1:7000
- Add support for activity text which also contain hostname, for example cassanadra/192.168.1.1:7000
- Add pytest for activity text regexp

A bit unsure where the trace.txt example come from, can it be DSE, I can not verify if this patch brake any other "CQL" environment, but tested against 4.0, 4.1, and 5.0 beta1 Apache Casandra (image from docker hub)